### PR TITLE
feat: Add wallet support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,15 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Debug tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": ["--inspect-brk", "${workspaceRoot}/node_modules/.bin/jest", "--runInBand"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "port": 9229
+    },
+    {
       "type": "node",
       "request": "launch",
       "name": "Launch Hello World",

--- a/README.md
+++ b/README.md
@@ -552,33 +552,38 @@ Lookup the primary Stellar account ID of a Keybase user.
 
 ##### Parameters
 
-- `name` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The name of the user you want to lookup.
+- `name` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The name of the user you want to lookup. This can be either a Keybase username or a username of another account that is supported by Keybase if it is followed by an '@<service>'.
 
 ##### Examples
 
 ```javascript
-const {accountID} = bot.wallet.lookup('patrick')
+const lookup1 = bot.wallet.lookup('patrick')
+// 'patrick' on Keybase is 'patrickxb' on twitter
+const lookup2 = bot.wallet.lookup('patrcikxb@twitter')
+// Using Lodash's `isEqual` since objects with same values aren't equal in JavaScript
+_.isEqual(lookup1, lookup2) // => true
 ```
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;{accountID: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), username: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)}>** An object containing the account ID and Keybase username of the found user.
 
 #### send
 
-Send money with your bot!
+Send lumens (XLM) via Keybase with your bot!
 
 ##### Parameters
 
-- `recipient` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Who you're sending your money to!
-- `amount` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** How much money to send.
-- `currency` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The currency of the value you're sending. If not included, defaults to XLM.
+- `recipient` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Who you're sending your money to. This can be a Keybase user, stellar address, or a username of another account that is supported by Keybase if it is followed by an '@<service>'.
+- `amount` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The amount of XLM to send.
+- `currency` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Adds a currency value to the amount specified. For example, adding 'USD' would send
 - `message` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The message for your payment
 
 ##### Examples
 
 ```javascript
-bot.wallet
-  .send('nathunsmitty', '3.50', 'USD', 'Shut up and take my money!')
-  .then(() => console.log('Money sent!'))
+bot.wallet.send('nathunsmitty', '3.50') // Send 3.50 XLM to Keybase user `nathunsmitty`
+bot.wallet.send('nathunsmitty@github', '3.50') // Send 3.50 XLM to GitHub user `nathunsmitty`
+bot.wallet.send('nathunsmitty', '3.50', 'USD') // Send $3.50 worth of lumens to Keybase user `nathunsmitty`
+bot.wallet.send('nathunsmitty', '3.50', 'USD', 'Shut up and take my money!') // Send $3.50 worth of lumens to Keybase user `nathunsmitty` with a memo
 ```
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[Transaction](#transaction)>** The trasaction object of the transaction.

--- a/README.md
+++ b/README.md
@@ -152,10 +152,12 @@ This code is also in [`demos/hello-world.js`](demos/hello-world.js), if you want
   - [Properties](#properties-9)
 - [ExchangeRate](#exchangerate)
   - [Properties](#properties-10)
-- [Account](#account)
+- [Balance](#balance)
   - [Properties](#properties-11)
-- [Transaction](#transaction)
+- [Account](#account)
   - [Properties](#properties-12)
+- [Transaction](#transaction)
+  - [Properties](#properties-13)
 
 ### Bot
 
@@ -630,18 +632,30 @@ Type: {currency: [string](https://developer.mozilla.org/docs/Web/JavaScript/Refe
 - `currency` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
 - `rate` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
 
+### Balance
+
+A balance.
+
+Type: {asset: [Asset](#asset), amount: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), limit: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)}
+
+#### Properties
+
+- `asset` **[Asset](#asset)**
+- `amount` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+- `limit` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+
 ### Account
 
 An account, with money inside!
 
-Type: {accountId: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), name: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), isPrimary: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean), balance: (null | [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;Balance>), exchangeRate: [ExchangeRate](#exchangerate)}
+Type: {accountId: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), name: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), isPrimary: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean), balance: (null | [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Balance](#balance)>), exchangeRate: [ExchangeRate](#exchangerate)}
 
 #### Properties
 
 - `accountId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
 - `name` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
 - `isPrimary` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)**
-- `balance` **(null | [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;Balance>)**
+- `balance` **(null | [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Balance](#balance)>)**
 - `exchangeRate` **[ExchangeRate](#exchangerate)**
 
 ### Transaction

--- a/README.md
+++ b/README.md
@@ -129,6 +129,33 @@ This code is also in [`demos/hello-world.js`](demos/hello-world.js), if you want
     - [Properties](#properties-8)
   - [OnMessage](#onmessage)
   - [OnError](#onerror)
+- [Wallet](#wallet)
+  - [balances](#balances)
+    - [Examples](#examples-10)
+  - [history](#history)
+    - [Parameters](#parameters-8)
+    - [Examples](#examples-11)
+  - [details](#details)
+    - [Parameters](#parameters-9)
+    - [Examples](#examples-12)
+  - [lookup](#lookup)
+    - [Parameters](#parameters-10)
+    - [Examples](#examples-13)
+  - [send](#send-1)
+    - [Parameters](#parameters-11)
+    - [Examples](#examples-14)
+  - [cancel](#cancel)
+    - [Parameters](#parameters-12)
+    - [Examples](#examples-15)
+- [PaymentStatus](#paymentstatus)
+- [Asset](#asset)
+  - [Properties](#properties-9)
+- [ExchangeRate](#exchangerate)
+  - [Properties](#properties-10)
+- [Account](#account)
+  - [Properties](#properties-11)
+- [Transaction](#transaction)
+  - [Properties](#properties-12)
 
 ### Bot
 
@@ -462,6 +489,184 @@ Type: function (message: MessageSummary): (void | [Promise](https://developer.mo
 A function to call when an error occurs.
 
 Type: function (error: [Error](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error)): (void | [Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;void>)
+
+### Wallet
+
+**Extends ClientBase**
+
+The wallet module of your Keybase bot. For more info about the API this module uses, you may want to check out `keybase wallet api`.
+
+#### balances
+
+Provides a list of all accounts owned by the current Keybase user.
+
+##### Examples
+
+```javascript
+bot.wallet.balances().then(accounts => console.log(accounts))
+```
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Account](#account)>>** An array of accounts. If there are no accounts, the array is empty.
+
+#### history
+
+Provides a list of all transactions in a single account.
+
+##### Parameters
+
+- `accountId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The id of an account owned by a Keybase user.
+
+##### Examples
+
+```javascript
+bot.wallet
+  .history('GDUKZH6Q3U5WQD4PDGZXYLJE3P76BDRDWPSALN4OUFEESI2QL5UZHCK')
+  .then(transactions => console.log(transactions))
+```
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Transaction](#transaction)>>** An array of transactions related to the account.
+
+#### details
+
+Get details about a particular transaction
+
+##### Parameters
+
+- `transactionId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The id of the transaction you would like details about.
+
+##### Examples
+
+```javascript
+bot.wallet
+  .details('e5334601b9dc2a24e031ffeec2fce37bb6a8b4b51fc711d16dec04d3e64976c4')
+  .then(details => console.log(details))
+```
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[Transaction](#transaction)>** An object of details about the transaction specified.
+
+#### lookup
+
+Lookup the primary Stellar account ID of a Keybase user.
+
+##### Parameters
+
+- `name` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The name of the user you want to lookup.
+
+##### Examples
+
+```javascript
+const {accountID} = bot.wallet.lookup('patrick')
+```
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;{accountID: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), username: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)}>** An object containing the account ID and Keybase username of the found user.
+
+#### send
+
+Send money with your bot!
+
+##### Parameters
+
+- `recipient` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Who you're sending your money to!
+- `amount` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** How much money to send.
+- `currency` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The currency of the value you're sending. If not included, defaults to XLM.
+- `message` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The message for your payment
+
+##### Examples
+
+```javascript
+bot.wallet
+  .send('nathunsmitty', '3.50', 'USD', 'Shut up and take my money!')
+  .then(() => console.log('Money sent!'))
+```
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[Transaction](#transaction)>** The trasaction object of the transaction.
+
+#### cancel
+
+If you send XLM to a Keybase user who has not established a wallet, you can cancel the payment before the recipient claims it and the XLM will be returned to your account.
+
+##### Parameters
+
+- `transactionId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The id of the transaction to cancel.
+
+##### Examples
+
+```javascript
+bot.wallet
+  .cancel('e5334601b9dc2a24e031ffeec2fce37bb6a8b4b51fc711d16dec04d3e64976c4')
+  .then(() => console.log('Transaction successfully canceled!'))
+```
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;void>**
+
+### PaymentStatus
+
+The status of a payment.
+
+Type: (`"none"` \| `"pending"` \| `"claimable"` \| `"completed"` \| `"error"` \| `"unknown"` \| `"canceled"`)
+
+### Asset
+
+An asset.
+
+Type: {type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), code: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), issuer: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), verifiedDomain: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), issuerName: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)}
+
+#### Properties
+
+- `type` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+- `code` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+- `issuer` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+- `verifiedDomain` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+- `issuerName` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+
+### ExchangeRate
+
+An exchange rate, which specifies a currency and the rate of exchange between an asset and that currency.
+
+Type: {currency: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), rate: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)}
+
+#### Properties
+
+- `currency` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+- `rate` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+
+### Account
+
+An account, with money inside!
+
+Type: {accountId: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), name: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), isPrimary: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean), balance: (null | [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;Balance>), exchangeRate: [ExchangeRate](#exchangerate)}
+
+#### Properties
+
+- `accountId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+- `name` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+- `isPrimary` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)**
+- `balance` **(null | [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;Balance>)**
+- `exchangeRate` **[ExchangeRate](#exchangerate)**
+
+### Transaction
+
+A transaction, where a user sends money to another user.
+
+Type: {txId: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), time: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number), status: [PaymentStatus](#paymentstatus), statusDetail: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), amount: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), asset: [Asset](#asset), displayAmount: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), displayCurrency: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), fromStellar: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), toStellar: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), fromUsername: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), toUsername: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), note: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), noteErr: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), unread: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)}
+
+#### Properties
+
+- `txId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+- `time` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)**
+- `status` **[PaymentStatus](#paymentstatus)**
+- `statusDetail` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+- `amount` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+- `asset` **[Asset](#asset)**
+- `displayAmount` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+- `displayCurrency` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+- `fromStellar` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+- `toStellar` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+- `fromUsername` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+- `toUsername` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+- `note` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+- `noteErr` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+- `unread` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)**
 
 ## Contributions
 

--- a/__tests__/tests.config.example.js
+++ b/__tests__/tests.config.example.js
@@ -18,6 +18,11 @@ module.exports = {
       username: 'bob',
       paperkey: 'one two three four...',
     },
+    charlie1: {
+      // Charlie should be an account that has access to Stellar features
+      username: 'charlie',
+      paperkey: 'get this bread...',
+    },
   },
   teams: {
     acme: {

--- a/__tests__/tests.config.example.js
+++ b/__tests__/tests.config.example.js
@@ -19,7 +19,7 @@ module.exports = {
       paperkey: 'one two three four...',
     },
     charlie1: {
-      // Charlie should be an account that has access to Stellar features
+      // Charlie should be an account that does not have access to Stellar features
       username: 'charlie',
       paperkey: 'get this bread...',
     },

--- a/__tests__/wallet.test.js
+++ b/__tests__/wallet.test.js
@@ -1,0 +1,36 @@
+import Bot from '../lib'
+import config from './tests.config.js'
+
+test('Wallet methods with an uninitialized bot', () => {
+  const alice1 = new Bot()
+
+  expect(alice1.wallet.balances()).rejects.toThrowError()
+})
+
+describe('Wallet Methods', () => {
+  const charlie1 = new Bot()
+
+  const accountMatcher = expect.objectContaining({
+    accountId: expect.any(String),
+    isPrimary: expect.any(Boolean),
+    name: expect.any(String),
+  })
+
+  beforeAll(async () => {
+    await charlie1.init(config.bots.charlie1.username, config.bots.charlie1.paperkey)
+  })
+
+  afterAll(async () => {
+    await charlie1.deinit()
+  })
+
+  describe('Wallet balances', () => {
+    it('Lists all of the accounts of a user', async () => {
+      const accounts = await charlie1.wallet.balances()
+      expect(Array.isArray(accounts)).toBe(true)
+      for (const account of accounts) {
+        expect(account).toEqual(accountMatcher)
+      }
+    })
+  })
+})

--- a/__tests__/wallet.test.js
+++ b/__tests__/wallet.test.js
@@ -35,11 +35,30 @@ describe('Wallet Methods', () => {
   })
 
   describe('Wallet history', () => {
-    it('Lists all the transactions of an account', async () => {
-      const accounts = await charlie1.wallet.balances()
-      const transactions = await charlie1.wallet.history(accounts[0].accountId)
-      expect(Array.isArray(transactions)).toBe(true)
-      console.log(transactions)
-    })
+    it('Provides the details of all transactions involving the specified account', () => {})
+    it('Throws an error if the accountId is invalid', () => {})
+  })
+
+  describe('Wallet details', () => {
+    it('Provides the details of a transaction by its id', () => {})
+    it('Throws an error if the transaction id is invalid', () => {})
+  })
+
+  describe('Wallet lookup', () => {
+    it("Returns a user's account id and Keybase username upon successful lookup", () => {})
+    it('Throws an error if a user has not set up their wallet', () => {})
+    it('Throws an error if a user cannot be found', () => {})
+  })
+
+  describe('Wallet send', () => {
+    it('Sends money', () => {})
+    it('Throws an error if given an invalid recipient', () => {})
+    it('Throws an error if given an invalid amount')
+    it('Throws an error if given an invalid currency')
+  })
+
+  describe('Wallet cancel', () => {
+    it('Successfully cancels transactions if to a user who has not set up their account', () => {})
+    it('Throws an error if it is given a transaction that cannot be canceled', () => {})
   })
 })

--- a/__tests__/wallet.test.js
+++ b/__tests__/wallet.test.js
@@ -33,7 +33,6 @@ describe('Wallet Methods', () => {
 
   afterAll(async () => {
     await alice.deinit()
-    // await bob.deinit()
   })
 
   describe('Wallet balances', () => {

--- a/__tests__/wallet.test.js
+++ b/__tests__/wallet.test.js
@@ -10,7 +10,6 @@ test('Wallet methods with an uninitialized bot', () => {
 
 describe('Wallet Methods', () => {
   const alice = new Bot()
-  const bob = new Bot()
 
   const accountMatcher = expect.objectContaining({
     accountId: expect.any(String),
@@ -20,16 +19,9 @@ describe('Wallet Methods', () => {
   const transactionMatcher = expect.objectContaining({
     txId: expect.any(String),
     time: expect.any(Number),
-    // status: PaymentStatus,
     statusDetail: expect.any(String),
     amount: expect.any(String),
-    // asset: Asset,
-    // displayAmount: expect.any(String),
-    // displayCurrency: expect.any(String),
     fromStellar: expect.any(String),
-    toStellar: expect.any(String),
-    // fromUsername: expect.any(String),
-    // toUsername: expect.any(String),
     note: expect.any(String),
     noteErr: expect.any(String),
     unread: expect.any(Boolean),
@@ -37,12 +29,11 @@ describe('Wallet Methods', () => {
 
   beforeAll(async () => {
     await alice.init(config.bots.alice1.username, config.bots.alice1.paperkey)
-    await bob.init(config.bots.bob1.username, config.bots.bob1.paperkey)
   })
 
   afterAll(async () => {
     await alice.deinit()
-    await bob.deinit()
+    // await bob.deinit()
   })
 
   describe('Wallet balances', () => {
@@ -106,11 +97,14 @@ describe('Wallet Methods', () => {
     const recipient = config.bots.bob1.username
 
     it('Sends money', async () => {
+      const bob = new Bot()
+      await bob.init(config.bots.bob1.username, config.bots.bob1.paperkey)
       const note = crypto.randomBytes(8).toString('hex')
       await alice.wallet.send(recipient, amount, currency, note)
       const primaryAccount = await alice.wallet.lookup(recipient)
       const transactions = await bob.wallet.history(primaryAccount.accountId)
       expect(transactions[0]).toHaveProperty('note', note)
+      await bob.deinit()
     })
     it('Throws an error if given an invalid recipient', () => {
       expect(alice.wallet.send('keybase', amount, currency)).rejects.toThrowError()

--- a/__tests__/wallet.test.js
+++ b/__tests__/wallet.test.js
@@ -1,3 +1,4 @@
+import crypto from 'crypto'
 import Bot from '../lib'
 import config from './tests.config.js'
 
@@ -8,7 +9,8 @@ test('Wallet methods with an uninitialized bot', () => {
 })
 
 describe('Wallet Methods', () => {
-  const charlie1 = new Bot()
+  const alice = new Bot()
+  const bob = new Bot()
 
   const accountMatcher = expect.objectContaining({
     accountId: expect.any(String),
@@ -34,16 +36,18 @@ describe('Wallet Methods', () => {
   })
 
   beforeAll(async () => {
-    await charlie1.init(config.bots.charlie1.username, config.bots.charlie1.paperkey)
+    await alice.init(config.bots.alice1.username, config.bots.alice1.paperkey)
+    await bob.init(config.bots.bob1.username, config.bots.bob1.paperkey)
   })
 
   afterAll(async () => {
-    await charlie1.deinit()
+    await alice.deinit()
+    await bob.deinit()
   })
 
   describe('Wallet balances', () => {
     it('Lists all of the accounts of a user', async () => {
-      const accounts = await charlie1.wallet.balances()
+      const accounts = await alice.wallet.balances()
       expect(Array.isArray(accounts)).toBe(true)
       for (const account of accounts) {
         expect(account).toEqual(accountMatcher)
@@ -53,8 +57,8 @@ describe('Wallet Methods', () => {
 
   describe('Wallet history', () => {
     it('Provides the details of all transactions involving the specified account', async () => {
-      const accounts = await charlie1.wallet.balances()
-      const transactions = await charlie1.wallet.history(accounts[0].accountId)
+      const accounts = await alice.wallet.balances()
+      const transactions = await alice.wallet.history(accounts[0].accountId)
       expect(Array.isArray(transactions)).toBe(true)
       for (const transaction of transactions) {
         expect(transaction).toEqual(transactionMatcher)
@@ -62,49 +66,77 @@ describe('Wallet Methods', () => {
     })
 
     it('Throws an error if the accountId is invalid', () => {
-      expect(charlie1.wallet.history('blah')).rejects.toThrowError()
+      expect(alice.wallet.history('blah')).rejects.toThrowError()
     })
   })
 
   describe('Wallet details', () => {
     it('Provides the details of a transaction by its id', async () => {
-      const accounts = await charlie1.wallet.balances()
-      const transactions = await charlie1.wallet.history(accounts[0].accountId)
+      const accounts = await alice.wallet.balances()
+      const transactions = await alice.wallet.history(accounts[0].accountId)
       const transactionId = transactions[0].txId
-      expect(await charlie1.wallet.details(transactionId)).toEqual(transactionMatcher)
+      expect(await alice.wallet.details(transactionId)).toEqual(transactionMatcher)
     })
     it('Throws an error if the transaction id is invalid', () => {
-      expect(charlie1.wallet.details('blah')).rejects.toThrowError()
+      expect(alice.wallet.details('blah')).rejects.toThrowError()
     })
   })
 
   describe('Wallet lookup', () => {
     it("Returns a user's account id and Keybase username upon successful lookup", async () => {
-      const fromKeybase = await charlie1.wallet.lookup('chris')
-      const fromTwitter = await charlie1.wallet.lookup('malgorithms@twitter')
+      const fromKeybase = await alice.wallet.lookup('chris')
+      const fromTwitter = await alice.wallet.lookup('malgorithms@twitter')
 
       expect(fromKeybase).toEqual(fromTwitter)
       expect(fromKeybase).toHaveProperty('accountId')
       expect(fromKeybase).toHaveProperty('username', 'chris')
     })
     it('Throws an error if a user has not set up their wallet', async () => {
-      // Bob hasn't set up his wallet yet
-      expect(charlie1.wallet.lookup(config.bots.bob1.username)).rejects.toThrowError()
+      // Charlie hasn't set up his wallet yet
+      expect(alice.wallet.lookup(config.bots.charlie1.username)).rejects.toThrowError()
     })
     it('Throws an error if a user cannot be found', async () => {
-      expect(charlie1.wallet.lookup('keybase')).rejects.toThrowError()
+      expect(alice.wallet.lookup('keybase')).rejects.toThrowError()
     })
   })
 
   describe('Wallet send', () => {
-    it('Sends money', () => {})
-    it('Throws an error if given an invalid recipient', () => {})
-    it('Throws an error if given an invalid amount', () => {})
-    it('Throws an error if given an invalid currency', () => {})
+    const amount = '1'
+    const currency = 'USD'
+    const recipient = config.bots.bob1.username
+
+    it('Sends money', async () => {
+      const note = crypto.randomBytes(8).toString('hex')
+      await alice.wallet.send(recipient, amount, currency, note)
+      const primaryAccount = await alice.wallet.lookup(recipient)
+      const transactions = await bob.wallet.history(primaryAccount.accountId)
+      expect(transactions[0]).toHaveProperty('note', note)
+    })
+    it('Throws an error if given an invalid recipient', () => {
+      expect(alice.wallet.send('keybase', amount, currency)).rejects.toThrowError()
+    })
+    it('Throws an error if given an invalid amount', () => {
+      expect(alice.wallet.send(recipient, '-100', currency)).rejects.toThrowError()
+    })
+    it('Throws an error if given an invalid currency', () => {
+      expect(alice.wallet.send(recipient, amount, 'blah')).rejects.toThrowError()
+    })
   })
 
   describe('Wallet cancel', () => {
-    it('Successfully cancels transactions if to a user who has not set up their account', () => {})
-    it('Throws an error if it is given a transaction that cannot be canceled', () => {})
+    it('Successfully cancels transactions if the recipient is a user who has not set up their account', async () => {
+      const res = await alice.wallet.send(config.bots.charlie1.username, '3')
+      expect(res.status).toBe('Claimable')
+      await alice.wallet.cancel(res.txId)
+      const {accountId} = await alice.wallet.lookup(config.bots.alice1.username)
+      const transactions = await alice.wallet.history(accountId)
+      expect(transactions[0]).toHaveProperty('txId', res.txId)
+      expect(transactions[0]).toHaveProperty('status', 'Canceled')
+    })
+    it('Throws an error if it is given a transaction that cannot be canceled', async () => {
+      const res = await alice.wallet.send(config.bots.bob1.username, '1')
+      expect(res.status).toBe('completed')
+      expect(alice.wallet.cancel(res.txId)).rejects.toThrowError()
+    })
   })
 })

--- a/__tests__/wallet.test.js
+++ b/__tests__/wallet.test.js
@@ -33,4 +33,13 @@ describe('Wallet Methods', () => {
       }
     })
   })
+
+  describe('Wallet history', () => {
+    it('Lists all the transactions of an account', async () => {
+      const accounts = await charlie1.wallet.balances()
+      const transactions = await charlie1.wallet.history(accounts[0].accountId)
+      expect(Array.isArray(transactions)).toBe(true)
+      console.log(transactions)
+    })
+  })
 })

--- a/__tests__/wallet.test.js
+++ b/__tests__/wallet.test.js
@@ -15,6 +15,23 @@ describe('Wallet Methods', () => {
     isPrimary: expect.any(Boolean),
     name: expect.any(String),
   })
+  const transactionMatcher = expect.objectContaining({
+    txId: expect.any(String),
+    time: expect.any(Number),
+    // status: PaymentStatus,
+    statusDetail: expect.any(String),
+    amount: expect.any(String),
+    // asset: Asset,
+    // displayAmount: expect.any(String),
+    // displayCurrency: expect.any(String),
+    fromStellar: expect.any(String),
+    toStellar: expect.any(String),
+    // fromUsername: expect.any(String),
+    // toUsername: expect.any(String),
+    note: expect.any(String),
+    noteErr: expect.any(String),
+    unread: expect.any(Boolean),
+  })
 
   beforeAll(async () => {
     await charlie1.init(config.bots.charlie1.username, config.bots.charlie1.paperkey)
@@ -35,26 +52,55 @@ describe('Wallet Methods', () => {
   })
 
   describe('Wallet history', () => {
-    it('Provides the details of all transactions involving the specified account', () => {})
-    it('Throws an error if the accountId is invalid', () => {})
+    it('Provides the details of all transactions involving the specified account', async () => {
+      const accounts = await charlie1.wallet.balances()
+      const transactions = await charlie1.wallet.history(accounts[0].accountId)
+      expect(Array.isArray(transactions)).toBe(true)
+      for (const transaction of transactions) {
+        expect(transaction).toEqual(transactionMatcher)
+      }
+    })
+
+    it('Throws an error if the accountId is invalid', () => {
+      expect(charlie1.wallet.history('blah')).rejects.toThrowError()
+    })
   })
 
   describe('Wallet details', () => {
-    it('Provides the details of a transaction by its id', () => {})
-    it('Throws an error if the transaction id is invalid', () => {})
+    it('Provides the details of a transaction by its id', async () => {
+      const accounts = await charlie1.wallet.balances()
+      const transactions = await charlie1.wallet.history(accounts[0].accountId)
+      const transactionId = transactions[0].txId
+      expect(await charlie1.wallet.details(transactionId)).toEqual(transactionMatcher)
+    })
+    it('Throws an error if the transaction id is invalid', () => {
+      expect(charlie1.wallet.details('blah')).rejects.toThrowError()
+    })
   })
 
   describe('Wallet lookup', () => {
-    it("Returns a user's account id and Keybase username upon successful lookup", () => {})
-    it('Throws an error if a user has not set up their wallet', () => {})
-    it('Throws an error if a user cannot be found', () => {})
+    it("Returns a user's account id and Keybase username upon successful lookup", async () => {
+      const fromKeybase = await charlie1.wallet.lookup('chris')
+      const fromTwitter = await charlie1.wallet.lookup('malgorithms@twitter')
+
+      expect(fromKeybase).toEqual(fromTwitter)
+      expect(fromKeybase).toHaveProperty('accountId')
+      expect(fromKeybase).toHaveProperty('username', 'chris')
+    })
+    it('Throws an error if a user has not set up their wallet', async () => {
+      // Bob hasn't set up his wallet yet
+      expect(charlie1.wallet.lookup(config.bots.bob1.username)).rejects.toThrowError()
+    })
+    it('Throws an error if a user cannot be found', async () => {
+      expect(charlie1.wallet.lookup('keybase')).rejects.toThrowError()
+    })
   })
 
   describe('Wallet send', () => {
     it('Sends money', () => {})
     it('Throws an error if given an invalid recipient', () => {})
-    it('Throws an error if given an invalid amount')
-    it('Throws an error if given an invalid currency')
+    it('Throws an error if given an invalid amount', () => {})
+    it('Throws an error if given an invalid currency', () => {})
   })
 
   describe('Wallet cancel', () => {

--- a/lib/chat-client/index.js
+++ b/lib/chat-client/index.js
@@ -60,6 +60,7 @@ class Chat extends ClientBase {
     if (!res) {
       throw new Error('Keybase chat send returned nothing.')
     }
+    // Removes a single object with property `msg`
     // TODO: include pagination?
     const cleanedRes = res.messages.map(message => message.msg)
     return cleanedRes

--- a/lib/chat-client/index.js
+++ b/lib/chat-client/index.js
@@ -15,8 +15,6 @@ import type {
   MessageNotification,
 } from './types'
 
-export type ApiCommandArg = {|method: string, options: Object, homeDir?: string|}
-
 /** A function to call when a message is received. */
 export type OnMessage = (message: MessageSummary) => void | Promise<void>
 /** A function to call when an error occurs. */

--- a/lib/client-base/index.js
+++ b/lib/client-base/index.js
@@ -1,7 +1,7 @@
 // @flow
 import type {ChildProcess} from 'child_process'
 import {formatAPIObjectInput, formatAPIObjectOutput, keybaseExec, keybaseStatus} from '../utils'
-import {API_VERSIONS} from '../constants'
+import {API_VERSIONS, type API_TYPES} from '../constants'
 
 export type Initialized = false | 'paperkey' | 'currentService'
 
@@ -9,7 +9,7 @@ export type InitOptions = {|
   verbose?: boolean,
 |}
 
-export type ApiCommandArg = {|apiName: string, method: string, options?: Object|}
+export type ApiCommandArg = {|apiName: API_TYPES, method: string, options?: Object|}
 
 /**
  * A Client base.
@@ -43,7 +43,7 @@ class ClientBase {
   }
 
   async _runApiCommand(arg: ApiCommandArg): Promise<any> {
-    const options = arg.options ? formatAPIObjectInput(arg.options) : undefined
+    const options = arg.options ? formatAPIObjectInput(arg.options, arg.apiName) : undefined
     const input = {
       method: arg.method,
       params: {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,7 +1,8 @@
 // @flow
-const API_VERSIONS = {
+export const API_VERSIONS = {
   chat: 1,
+  team: 1,
   wallet: 1,
 }
 
-export {API_VERSIONS}
+export type API_TYPES = 'chat' | 'team' | 'wallet'

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,6 +1,7 @@
 // @flow
 const API_VERSIONS = {
   chat: 1,
+  wallet: 1,
 }
 
 export {API_VERSIONS}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,20 +1,25 @@
 // @flow
 import Service, {type InitOptions} from './service'
 import ChatClient from './chat-client'
+import WalletClient from './wallet-client'
 import type {BotInfo} from './utils/keybaseStatus'
 
 /** A Keybase bot. */
 class Bot {
   chat: ChatClient
+  wallet: WalletClient
   _service: Service
 
   /**
    * Create a bot. Note you can't do much too exciting with your bot after you instantiate it; you have to initialize it first.
    * @memberof Bot
+   * @example
+   * const bot = new Bot()
    */
   constructor() {
     this._service = new Service()
     this.chat = new ChatClient()
+    this.wallet = new WalletClient()
   }
 
   /**
@@ -72,6 +77,7 @@ class Bot {
     const info = this.myInfo()
     if (info) {
       await this.chat._init(info.homeDir, options)
+      await this.wallet._init(info.homeDir, options)
     } else {
       throw new Error('Issue initializing bot.')
     }

--- a/lib/utils/formatAPIObject.js
+++ b/lib/utils/formatAPIObject.js
@@ -1,32 +1,38 @@
 // @flow
 import snakeCase from 'lodash.snakecase'
 import camelCase from 'lodash.camelcase'
-
-// Recursively convert from camelCase to snake_case for any obj object for keybase chat api
+import kebabCase from 'lodash.kebabcase'
+import type {API_TYPES} from '../constants'
 
 /**
-  Takes a Keybase API input JavaScript object and formats it into snake_case instead of camelCase for the service.
+  Takes a Keybase API input JavaScript object and recursively formats it into snake_case or kebab-case instead of camelCase for the service.
   * @ignore
   * @param obj - The object to be formatted.
+  * @param apiType - The type of api the the input is being served to. Currently Keybase has chat, team, and wallet apis.
   * @returns - The new, formatted object.
   * @example
   * const inputOptions = formatAPIObject({unreadOnly: true})
   * console.log(inputOptions) // {unread_only: true}
  */
-export function formatAPIObjectInput(obj: any): any {
-  if (obj == null || typeof obj !== 'object') {
+export function formatAPIObjectInput(obj: any, apiType: API_TYPES): any {
+  if (obj === null || obj === undefined || typeof obj !== 'object') {
     return obj
   } else if (Array.isArray(obj)) {
-    return obj.map(item => formatAPIObjectInput(item))
+    return obj.map(item => formatAPIObjectInput(item, apiType))
   } else {
     return Object.keys(obj).reduce((newObj, key) => {
+      // TODO: hopefully we standardize how the Keybase API handles input keys
+      let formattedKey
+      if (apiType === 'wallet') {
+        formattedKey = kebabCase(key)
+      } else {
+        formattedKey = snakeCase(key)
+      }
+
       if (typeof obj[key] === 'object') {
-        return {...newObj, [snakeCase(key)]: formatAPIObjectInput(obj[key])}
+        return {...newObj, [formattedKey]: formatAPIObjectInput(obj[key], apiType)}
       }
-      return {
-        ...newObj,
-        [snakeCase(key)]: obj[key],
-      }
+      return {...newObj, [formattedKey]: obj[key]}
     }, {})
   }
 }
@@ -47,10 +53,11 @@ export function formatAPIObjectOutput(obj: any): any {
     return obj.map(item => formatAPIObjectOutput(item))
   } else {
     return Object.keys(obj).reduce((newObj, key) => {
+      const formattedKey = camelCase(key)
       if (typeof obj[key] === 'object') {
-        return {...newObj, [camelCase(key)]: formatAPIObjectOutput(obj[key])}
+        return {...newObj, [formattedKey]: formatAPIObjectOutput(obj[key])}
       }
-      return {...newObj, [camelCase(key)]: obj[key]}
+      return {...newObj, [formattedKey]: obj[key]}
     }, {})
   }
 }

--- a/lib/utils/formatAPIObject.test.js
+++ b/lib/utils/formatAPIObject.test.js
@@ -10,13 +10,22 @@ describe('formatAPIObjectInput', () => {
         memberIds: [1, 2, 3, 4, 5],
       },
     }
-    const formattedInput = formatAPIObjectInput(input)
+    let formattedInput = formatAPIObjectInput(input, 'chat')
     expect(formattedInput).toEqual({
       conversation_id: 'blah',
       nonblock: false,
       members: {
         member_type: 'user',
         member_ids: [1, 2, 3, 4, 5],
+      },
+    })
+    formattedInput = formatAPIObjectInput(input, 'wallet')
+    expect(formattedInput).toEqual({
+      'conversation-id': 'blah',
+      nonblock: false,
+      members: {
+        'member-type': 'user',
+        'member-ids': [1, 2, 3, 4, 5],
       },
     })
   })

--- a/lib/wallet-client/index.js
+++ b/lib/wallet-client/index.js
@@ -83,18 +83,20 @@ class Wallet extends ClientBase {
    * @memberof Wallet
    * @param recipient - Who you're sending your money to!
    * @param amount - How much money to send.
-   * @param currency - The currency of the value you're sending.
+   * @param [currency] - The currency of the value you're sending. If not included, defaults to XLM.
    * @param [message] - The message for your payment
+   * @returns - The trasaction object of the transaction.
    * @example
-   * bot.wallet.send('nathunsmitty', 10, 'USD', 'Shut up and take my money!').then(() => console.log('Money sent!'))
+   * bot.wallet.send('nathunsmitty', '3.50', 'USD', 'Shut up and take my money!').then(() => console.log('Money sent!'))
    */
-  async send(recipient: string, amount: number, currency: string, message?: string): Promise<void> {
+  async send(recipient: string, amount: string, currency?: string, message?: string): Promise<Transaction> {
     await this._guardInitialized()
     const options = {recipient, amount, currency, message}
     const res = await this._runApiCommand({apiName: 'wallet', method: 'send', options})
     if (!res) {
       throw new Error('Keybase wallet send returned nothing.')
     }
+    return res
   }
 
   /**

--- a/lib/wallet-client/index.js
+++ b/lib/wallet-client/index.js
@@ -5,7 +5,7 @@ import type {Account} from './types'
 /** The wallet module of your Keybase bot. For more info about the API this module uses, you may want to check out `keybase wallet api`. */
 class Wallet extends ClientBase {
   /**
-   * Lists your chats, with info on which ones have unread messages.
+   * Provides a list of all accounts owned by the current Keybase user.
    * @memberof Wallet
    * @returns - An array of accounts. If there are no accounts, the array is empty.
    * @example
@@ -19,6 +19,44 @@ class Wallet extends ClientBase {
     }
     return res || []
   }
+
+  /**
+   * Provides a list of all transactions in a single account.
+   * @memberof Wallet
+   * @param accountId - The id of an account owned by a Keybase user.
+   * @returns - An array of transactions related to the account.
+   * @example
+   * bot.wallet.history('GDUKZH6Q3U5WQD4PDGZXYLJE3P76BDRDWPSALN4OUFEESI2QL5UZHCK').then(transactions => console.log(transactions))
+   */
+  async history(accountId: string): Promise<any> {}
+
+  /**
+   * Get details about a particular transaction
+   * @memberof Wallet
+   * @param transactionId - The id of the transaction you would like details about.
+   * @returns - An object of details about the transaction specified.
+   * @example
+   * bot.wallet.details('e5334601b9dc2a24e031ffeec2fce37bb6a8b4b51fc711d16dec04d3e64976c4').then(details => console.log(details))
+   */
+  async details(transactionId: string): Promise<any> {}
+
+  /**
+   * Send money with your bot!
+   * @memberof Wallet
+   * @param recipient - Who you're sending your money to!
+   * @param amount - How much money to send.
+   * @param currency - The currency of the value you're sending.
+   * @param [message] - The message for your payment
+   * @example
+   */
+  async send(recipient: string, amount: number, currency: string, message?: string) {}
+
+  /**
+   * If you send XLM to a Keybase user who has not established a wallet, you can cancel the payment before the recipient claims it and the XLM will be returned to your account.
+   * @memberof Wallet
+   * @param transactionId - The id of the transaction to cancel.
+   */
+  async cancel(transactionId: string): Promise<void> {}
 }
 
 export default Wallet

--- a/lib/wallet-client/index.js
+++ b/lib/wallet-client/index.js
@@ -50,13 +50,23 @@ class Wallet extends ClientBase {
    * @example
    * bot.wallet.details('e5334601b9dc2a24e031ffeec2fce37bb6a8b4b51fc711d16dec04d3e64976c4').then(details => console.log(details))
    */
-  async details(transactionId: string): Promise<any> {}
+  async details(transactionId: string): Promise<Transaction> {
+    await this._guardInitialized()
+    const options = {txid: transactionId}
+    const res = await this._runApiCommand({apiName: 'wallet', method: 'details', options: options})
+    if (!res) {
+      throw new Error('Keybase wallet details returned nothing.')
+    }
+    return res
+  }
 
   /**
    * Lookup the primary Stellar account ID of a Keybase user.
    * @memberof Wallet
    * @param name - The name of the user you want to lookup.
-   * @returns -
+   * @returns - An object containing the account ID and Keybase username of the found user.
+   * @example
+   * const {accountID} = bot.wallet.lookup('patrick')
    */
   async lookup(name: string): Promise<{|accountID: string, username: string|}> {
     await this._guardInitialized()
@@ -76,15 +86,32 @@ class Wallet extends ClientBase {
    * @param currency - The currency of the value you're sending.
    * @param [message] - The message for your payment
    * @example
+   * bot.wallet.send('nathunsmitty', 10, 'USD', 'Shut up and take my money!').then(() => console.log('Money sent!'))
    */
-  async send(recipient: string, amount: number, currency: string, message?: string) {}
+  async send(recipient: string, amount: number, currency: string, message?: string): Promise<void> {
+    await this._guardInitialized()
+    const options = {recipient, amount, currency, message}
+    const res = await this._runApiCommand({apiName: 'wallet', method: 'send', options})
+    if (!res) {
+      throw new Error('Keybase wallet send returned nothing.')
+    }
+  }
 
   /**
    * If you send XLM to a Keybase user who has not established a wallet, you can cancel the payment before the recipient claims it and the XLM will be returned to your account.
    * @memberof Wallet
    * @param transactionId - The id of the transaction to cancel.
+   * @example
+   * bot.wallet.cancel('e5334601b9dc2a24e031ffeec2fce37bb6a8b4b51fc711d16dec04d3e64976c4').then(() => console.log('Transaction successfully canceled!'))
    */
-  async cancel(transactionId: string): Promise<void> {}
+  async cancel(transactionId: string): Promise<void> {
+    await this._guardInitialized()
+    const options = {txid: transactionId}
+    const res = await this._runApiCommand({apiName: 'wallet', method: 'cancel', options})
+    if (!res) {
+      throw new Error('Keybase wallet cancel returned nothing.')
+    }
+  }
 }
 
 export default Wallet

--- a/lib/wallet-client/index.js
+++ b/lib/wallet-client/index.js
@@ -1,0 +1,24 @@
+// @flow
+import ClientBase from '../client-base'
+import type {Account} from './types'
+
+/** The wallet module of your Keybase bot. For more info about the API this module uses, you may want to check out `keybase wallet api`. */
+class Wallet extends ClientBase {
+  /**
+   * Lists your chats, with info on which ones have unread messages.
+   * @memberof Wallet
+   * @returns - An array of accounts. If there are no accounts, the array is empty.
+   * @example
+   * bot.wallet.balances().then(accounts => console.log(accounts))
+   */
+  async balances(): Promise<Account[]> {
+    await this._guardInitialized()
+    const res = await this._runApiCommand({apiName: 'wallet', method: 'balances'})
+    if (!res) {
+      throw new Error('Keybase wallet balanaces returned nothing.')
+    }
+    return res || []
+  }
+}
+
+export default Wallet

--- a/lib/wallet-client/index.js
+++ b/lib/wallet-client/index.js
@@ -52,7 +52,21 @@ class Wallet extends ClientBase {
    */
   async details(transactionId: string): Promise<any> {}
 
-  async lookup(): Promise<any> {}
+  /**
+   * Lookup the primary Stellar account ID of a Keybase user.
+   * @memberof Wallet
+   * @param name - The name of the user you want to lookup.
+   * @returns -
+   */
+  async lookup(name: string): Promise<{|accountID: string, username: string|}> {
+    await this._guardInitialized()
+    const options = {name}
+    const res = await this._runApiCommand({apiName: 'wallet', method: 'lookup', options})
+    if (!res) {
+      throw new Error('Keybase wallet lookup returned nothing.')
+    }
+    return res
+  }
 
   /**
    * Send money with your bot!

--- a/lib/wallet-client/index.js
+++ b/lib/wallet-client/index.js
@@ -28,7 +28,20 @@ class Wallet extends ClientBase {
    * @example
    * bot.wallet.history('GDUKZH6Q3U5WQD4PDGZXYLJE3P76BDRDWPSALN4OUFEESI2QL5UZHCK').then(transactions => console.log(transactions))
    */
-  async history(accountId: string): Promise<any> {}
+  async history(accountId: string): Promise<any> {
+    await this._guardInitialized()
+    const options = {
+      accountId,
+    }
+    const res = await this._runApiCommand({apiName: 'wallet', method: 'history', options: options})
+    if (!res) {
+      throw new Error('Keybase wallet history returned nothing.')
+    }
+    // Removes a single object with property `payment`
+    // TODO: include pagination?
+    const cleanedRes = res.map(payment => payment.payment)
+    return cleanedRes
+  }
 
   /**
    * Get details about a particular transaction

--- a/lib/wallet-client/index.js
+++ b/lib/wallet-client/index.js
@@ -63,10 +63,14 @@ class Wallet extends ClientBase {
   /**
    * Lookup the primary Stellar account ID of a Keybase user.
    * @memberof Wallet
-   * @param name - The name of the user you want to lookup.
+   * @param name - The name of the user you want to lookup. This can be either a Keybase username or a username of another account that is supported by Keybase if it is followed by an '@<service>'.
    * @returns - An object containing the account ID and Keybase username of the found user.
    * @example
-   * const {accountID} = bot.wallet.lookup('patrick')
+   * const lookup1 = bot.wallet.lookup('patrick')
+   * // 'patrick' on Keybase is 'patrickxb' on twitter
+   * const lookup2 = bot.wallet.lookup('patrcikxb@twitter')
+   * // Using Lodash's `isEqual` since objects with same values aren't equal in JavaScript
+   * _.isEqual(lookup1, lookup2) // => true
    */
   async lookup(name: string): Promise<{|accountID: string, username: string|}> {
     await this._guardInitialized()
@@ -79,15 +83,18 @@ class Wallet extends ClientBase {
   }
 
   /**
-   * Send money with your bot!
+   * Send lumens (XLM) via Keybase with your bot!
    * @memberof Wallet
-   * @param recipient - Who you're sending your money to!
-   * @param amount - How much money to send.
-   * @param [currency] - The currency of the value you're sending. If not included, defaults to XLM.
+   * @param recipient - Who you're sending your money to. This can be a Keybase user, stellar address, or a username of another account that is supported by Keybase if it is followed by an '@<service>'.
+   * @param amount - The amount of XLM to send.
+   * @param [currency] - Adds a currency value to the amount specified. For example, adding 'USD' would send
    * @param [message] - The message for your payment
    * @returns - The trasaction object of the transaction.
    * @example
-   * bot.wallet.send('nathunsmitty', '3.50', 'USD', 'Shut up and take my money!').then(() => console.log('Money sent!'))
+   * bot.wallet.send('nathunsmitty', '3.50') // Send 3.50 XLM to Keybase user `nathunsmitty`
+   * bot.wallet.send('nathunsmitty@github', '3.50') // Send 3.50 XLM to GitHub user `nathunsmitty`
+   * bot.wallet.send('nathunsmitty', '3.50', 'USD') // Send $3.50 worth of lumens to Keybase user `nathunsmitty`
+   * bot.wallet.send('nathunsmitty', '3.50', 'USD', 'Shut up and take my money!') // Send $3.50 worth of lumens to Keybase user `nathunsmitty` with a memo
    */
   async send(recipient: string, amount: string, currency?: string, message?: string): Promise<Transaction> {
     await this._guardInitialized()

--- a/lib/wallet-client/index.js
+++ b/lib/wallet-client/index.js
@@ -1,6 +1,6 @@
 // @flow
 import ClientBase from '../client-base'
-import type {Account} from './types'
+import type {Account, Transaction} from './types'
 
 /** The wallet module of your Keybase bot. For more info about the API this module uses, you may want to check out `keybase wallet api`. */
 class Wallet extends ClientBase {
@@ -28,7 +28,7 @@ class Wallet extends ClientBase {
    * @example
    * bot.wallet.history('GDUKZH6Q3U5WQD4PDGZXYLJE3P76BDRDWPSALN4OUFEESI2QL5UZHCK').then(transactions => console.log(transactions))
    */
-  async history(accountId: string): Promise<any> {
+  async history(accountId: string): Promise<Transaction[]> {
     await this._guardInitialized()
     const options = {
       accountId,
@@ -38,7 +38,6 @@ class Wallet extends ClientBase {
       throw new Error('Keybase wallet history returned nothing.')
     }
     // Removes a single object with property `payment`
-    // TODO: include pagination?
     const cleanedRes = res.map(payment => payment.payment)
     return cleanedRes
   }
@@ -52,6 +51,8 @@ class Wallet extends ClientBase {
    * bot.wallet.details('e5334601b9dc2a24e031ffeec2fce37bb6a8b4b51fc711d16dec04d3e64976c4').then(details => console.log(details))
    */
   async details(transactionId: string): Promise<any> {}
+
+  async lookup(): Promise<any> {}
 
   /**
    * Send money with your bot!

--- a/lib/wallet-client/types.js
+++ b/lib/wallet-client/types.js
@@ -25,6 +25,9 @@ export type ExchangeRate = {|
   rate: string,
 |}
 
+/**
+ * A balance.
+ */
 export type Balance = {|
   asset: Asset,
   amount: string,

--- a/lib/wallet-client/types.js
+++ b/lib/wallet-client/types.js
@@ -1,0 +1,10 @@
+// @flow
+// https://github.com/keybase/client/blob/8abfc8dc60baf072b62e12b92a6ce1b81ce39cf3/go/protocol/stellar1/local.go
+
+export type Account = {|
+  accountId: string,
+  name: string,
+  isPrimary: boolean,
+  balance: any,
+  exchangeRate: any,
+|}

--- a/lib/wallet-client/types.js
+++ b/lib/wallet-client/types.js
@@ -6,6 +6,9 @@
  */
 export type PaymentStatus = 'none' | 'pending' | 'claimable' | 'completed' | 'error' | 'unknown' | 'canceled'
 
+/**
+ * An asset.
+ */
 export type Asset = {|
   type: string,
   code: string,
@@ -15,21 +18,35 @@ export type Asset = {|
 |}
 
 /**
+ * An exchange rate, which specifies a currency and the rate of exchange between an asset and that currency.
+ */
+export type ExchangeRate = {|
+  currency: string,
+  rate: string,
+|}
+
+export type Balance = {|
+  asset: Asset,
+  amount: string,
+  limit: string,
+|}
+
+/**
  * An account, with money inside!
  */
 export type Account = {|
   accountId: string,
   name: string,
   isPrimary: boolean,
-  balance: any,
-  exchangeRate: any,
+  balance: null | Balance[],
+  exchangeRate: ExchangeRate,
 |}
 
 /**
  * A transaction, where a user sends money to another user.
  */
 export type Transaction = {|
-  txID: string,
+  txId: string,
   time: number,
   status: PaymentStatus,
   statusDetail: string,

--- a/lib/wallet-client/types.js
+++ b/lib/wallet-client/types.js
@@ -1,10 +1,47 @@
 // @flow
 // https://github.com/keybase/client/blob/8abfc8dc60baf072b62e12b92a6ce1b81ce39cf3/go/protocol/stellar1/local.go
 
+/**
+ * The status of a payment.
+ */
+export type PaymentStatus = 'none' | 'pending' | 'claimable' | 'completed' | 'error' | 'unknown' | 'canceled'
+
+export type Asset = {|
+  type: string,
+  code: string,
+  issuer: string,
+  verifiedDomain: string,
+  issuerName: string,
+|}
+
+/**
+ * An account, with money inside!
+ */
 export type Account = {|
   accountId: string,
   name: string,
   isPrimary: boolean,
   balance: any,
   exchangeRate: any,
+|}
+
+/**
+ * A transaction, where a user sends money to another user.
+ */
+export type Transaction = {|
+  txID: string,
+  time: number,
+  status: PaymentStatus,
+  statusDetail: string,
+  amount: string,
+  asset: Asset,
+  displayAmount: string,
+  displayCurrency: string,
+  fromStellar: string,
+  toStellar: string,
+  fromUsername: string,
+  toUsername: string,
+  note: string,
+  noteErr: string,
+  unread: boolean,
 |}

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "lodash.camelcase": "4.3.0",
+    "lodash.kebabcase": "4.1.1",
     "lodash.snakecase": "4.1.1"
   },
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,6 +19,7 @@ export default {
     'readline',
     'lodash.snakecase',
     'lodash.camelcase',
+    'lodash.kebabcase',
     'fs',
     'os',
     'path',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4714,6 +4714,7 @@ lodash.debounce@^4.0.8:
 lodash.kebabcase@4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
+  integrity sha1-hImxyw0p/4gZXM7KRI/21swpXDY=
 
 lodash.snakecase@4.1.1:
   version "4.1.1"


### PR DESCRIPTION
Supported wallet methods:
- balances
- history
- details
- lookup
- send
- cancel

I didn't implement the inflation methods just yet because those seemed a little niche, and I wanted to get a base implementation done first.

Other notes:
- I added breakpoint debugging support for our jest tests in VS Code
- Some wallet tests require a user who hasn't yet set up a wallet; this required a new bot named charlie.
- The wallet api uses different casing than the chat api, so formatAPIObject now supports kebab-case