### PR TITLE
bot lite mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,23 +255,26 @@ A collection of types used by the bot.
 
 Options for initializing the bot.
 
-Type: {verbose: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?}
+Type: {verbose: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?, botLite: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?}
 
 ##### Properties
 
 - `verbose` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?**
+- `botLite` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?**
 
 #### BotInfo
 
 Useful information like the username, device, and home directory of your bot.
 
-Type: {username: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), devicename: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), homeDir: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?}
+Type: {username: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), devicename: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), homeDir: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?, botLite: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?}
+}
 
 ##### Properties
 
 - `username` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
 - `devicename` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
 - `homeDir` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?**
+- `botLite` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?**
 
 ### Chat
 

--- a/README.md
+++ b/README.md
@@ -255,12 +255,14 @@ A collection of types used by the bot.
 
 Options for initializing the bot.
 
-Type: {verbose: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?, botLite: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?}
+Type: {verbose: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?, botLite: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?, disableTyping: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?}
+}
 
 ##### Properties
 
 - `verbose` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?**
 - `botLite` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?**
+- `disableTyping` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?**
 
 #### BotInfo
 
@@ -275,6 +277,7 @@ Type: {username: [string](https://developer.mozilla.org/docs/Web/JavaScript/Refe
 - `devicename` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
 - `homeDir` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?**
 - `botLite` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?**
+- `disableTyping` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?**
 
 ### Chat
 

--- a/__tests__/init.test.js
+++ b/__tests__/init.test.js
@@ -60,7 +60,7 @@ describe('Keybase bot initialization', () => {
     const alice = new Bot()
     await alice.init(config.bots.alice1.username, config.bots.alice1.paperkey)
     expect(alice.myInfo().botLite).toBe(true)
-    expect(alice.myInfo().displayTyping).toBe(true)
+    expect(alice.myInfo().disableTyping).toBe(true)
     await alice.deinit()
   })
 

--- a/__tests__/init.test.js
+++ b/__tests__/init.test.js
@@ -55,4 +55,25 @@ describe('Keybase bot initialization', () => {
     await alice.deinit()
     await stopServiceManually(homeDir)
   })
+
+  it('can init with botLite enabled by default', async () => {
+    const alice = new Bot()
+    await alice.init(config.bots.alice1.username, config.bots.alice1.paperkey)
+    expect(alice.myInfo().botLite).toBe(true)
+    await alice.deinit()
+  })
+
+  it('can respect disabling botLite', async () => {
+    const alice = new Bot()
+    await alice.init(config.bots.alice1.username, config.bots.alice1.paperkey, {botLite: false})
+    expect(alice.myInfo().botLite).toBe(false)
+    await alice.deinit()
+  })
+
+  it('can config without botLite', async () => {
+    const alice = new Bot()
+    await alice.init(config.bots.alice1.username, config.bots.alice1.paperkey, {verbose: true})
+    expect(alice.myInfo().botLite).toBe(true)
+    await alice.deinit()
+  })
 })

--- a/__tests__/init.test.js
+++ b/__tests__/init.test.js
@@ -56,24 +56,30 @@ describe('Keybase bot initialization', () => {
     await stopServiceManually(homeDir)
   })
 
-  it('can init with botLite enabled by default', async () => {
+  it('can init with botLite/disableTyping enabled by default', async () => {
     const alice = new Bot()
     await alice.init(config.bots.alice1.username, config.bots.alice1.paperkey)
     expect(alice.myInfo().botLite).toBe(true)
+    expect(alice.myInfo().displayTyping).toBe(true)
     await alice.deinit()
   })
 
-  it('can respect disabling botLite', async () => {
+  it('can respect disabling botLite and disableTyping', async () => {
     const alice = new Bot()
-    await alice.init(config.bots.alice1.username, config.bots.alice1.paperkey, {botLite: false})
+    await alice.init(config.bots.alice1.username, config.bots.alice1.paperkey, {
+      botLite: false,
+      disableTyping: false,
+    })
     expect(alice.myInfo().botLite).toBe(false)
+    expect(alice.myInfo().disableTyping).toBe(false)
     await alice.deinit()
   })
 
-  it('can config without botLite', async () => {
+  it('can config without botLite or disableTyping', async () => {
     const alice = new Bot()
     await alice.init(config.bots.alice1.username, config.bots.alice1.paperkey, {verbose: true})
     expect(alice.myInfo().botLite).toBe(true)
+    expect(alice.myInfo().disableTyping).toBe(true)
     await alice.deinit()
   })
 })

--- a/__tests__/myInfo.test.js
+++ b/__tests__/myInfo.test.js
@@ -3,7 +3,7 @@ import config from './tests.config.js'
 import {publicPaperkeyLabel} from './test-utils'
 
 describe('bot.myInfo()', () => {
-  it('returns a username, devicename, and homeDir when the bot is initialized', async () => {
+  it('returns a username, devicename, homeDir, and service config options when the bot is initialized', async () => {
     const alice = new Bot()
     await alice.init(config.bots.alice1.username, config.bots.alice1.paperkey)
     const aliceInfo = alice.myInfo()
@@ -11,6 +11,7 @@ describe('bot.myInfo()', () => {
     expect(aliceInfo.username).toBe(config.bots.alice1.username)
     expect(aliceInfo.devicename).toBe(publicPaperkeyLabel(config.bots.alice1.paperkey))
     expect(aliceInfo).toHaveProperty('homeDir')
+    expect(aliceInfo.botLite).toBe(true)
     await alice.deinit()
   })
 

--- a/__tests__/myInfo.test.js
+++ b/__tests__/myInfo.test.js
@@ -12,6 +12,7 @@ describe('bot.myInfo()', () => {
     expect(aliceInfo.devicename).toBe(publicPaperkeyLabel(config.bots.alice1.paperkey))
     expect(aliceInfo).toHaveProperty('homeDir')
     expect(aliceInfo.botLite).toBe(true)
+    expect(aliceInfo.disableTyping).toBe(true)
     await alice.deinit()
   })
 

--- a/__tests__/test-utils/startServiceManually.js
+++ b/__tests__/test-utils/startServiceManually.js
@@ -5,7 +5,7 @@ import {keybaseExec, whichKeybase} from '../../lib/utils'
 import path from 'path'
 
 function keybaseServiceStartup(homeDir: string): Promise<void> {
-  const child = spawn('keybase', ['--home', homeDir, 'service'])
+  const child = spawn('keybase', ['--home', homeDir, '--enable-bot-lite-mode', 'service'])
   const lineReader = readline.createInterface({input: child.stderr})
   return new Promise((resolve, reject) => {
     child.on('close', code => {

--- a/lib/client-base/index.js
+++ b/lib/client-base/index.js
@@ -1,12 +1,9 @@
 // @flow
 import type {ChildProcess} from 'child_process'
 import {formatAPIObjectInput, formatAPIObjectOutput, keybaseExec, keybaseStatus} from '../utils'
+import type {InitOptions} from '../utils/options'
 import {API_VERSIONS, type API_TYPES} from '../constants'
 import path from 'path'
-
-export type InitOptions = {|
-  verbose?: boolean,
-|}
 
 export type ApiCommandArg = {|apiName: API_TYPES, method: string, options?: Object|}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 // @flow
-import Service, {type InitOptions} from './service'
+import Service from './service'
 import ChatClient from './chat-client'
 import WalletClient from './wallet-client'
 import type {BotInfo} from './utils/keybaseStatus'
@@ -8,6 +8,7 @@ import {randomTempDir, whichKeybase, rmdirRecursive} from './utils'
 import {promisify} from 'util'
 import {copyFile} from 'fs'
 import path from 'path'
+import type {InitOptions} from './utils/options'
 
 /** A Keybase bot. */
 class Bot {

--- a/lib/service/index.js
+++ b/lib/service/index.js
@@ -2,15 +2,8 @@
 import {keybaseExec, keybaseStatus, pingKeybaseService, timeout} from '../utils'
 import {spawn} from 'child_process'
 import type {BotInfo} from '../utils/keybaseStatus'
+import type {InitOptions} from '../utils/options'
 import path from 'path'
-
-/**
- * Options for initializing the bot.
- */
-export type InitOptions = {|
-  verbose?: boolean,
-  botLite?: boolean,
-|}
 
 class Service {
   initialized: false | 'paperkey' | 'runningService'
@@ -43,7 +36,7 @@ class Service {
 
     this.homeDir = this.workingDir
     this.serviceLogFile = path.join(this.homeDir, 'Library', 'Logs', 'keybase.service.log')
-    this.botLite = options ? Boolean(options.botLite) : true
+    this.botLite = options ? Boolean(typeof options.botLite !== 'boolean' || options.botLite) : true
     // Unlike with clients we don't need to store the service, since it shuts down with ctrl stop
     try {
       await this.startupService()
@@ -125,6 +118,7 @@ class Service {
         username: this.username,
         devicename: this.devicename,
         homeDir: this.homeDir ? this.homeDir : undefined,
+        botLite: this.botLite,
       }
     }
     return null
@@ -149,7 +143,7 @@ class Service {
     if (this.botLite) {
       args.unshift('--enable-bot-lite-mode')
     }
-    const child = spawn('keybase', args, process.env)})
+    const child = spawn('keybase', args, {env: process.env})
 
     // keep track of the subprocess' state
     this.running = true

--- a/lib/service/index.js
+++ b/lib/service/index.js
@@ -50,7 +50,7 @@ class Service {
       })
 
       // Set the typing notification settings for the bot
-      await keybaseExec(this.homeDir, [
+      await keybaseExec(this.workingDir, this.homeDir, [
         'chat',
         'notification-settings',
         'disable-typing',

--- a/lib/service/index.js
+++ b/lib/service/index.js
@@ -18,12 +18,14 @@ class Service {
   devicename: void | string
   homeDir: void | string
   verbose: boolean
+  botLite: boolean
   serviceLogFile: void | string
   workingDir: string
   constructor(workingDir: string) {
     this.workingDir = workingDir
     this.initialized = false
     this.verbose = false
+    this.botLite = true
   }
 
   async init(username: string, paperkey: string, options?: InitOptions): Promise<void> {
@@ -54,6 +56,7 @@ class Service {
         this.username = currentInfo.username
         this.devicename = currentInfo.devicename
         this.verbose = options ? Boolean(options.verbose) : false
+        this.botLite = options ? Boolean(options.botLite) : true
       }
       if (this.username !== username) {
         throw new Error('Failed to initialize service.')
@@ -76,6 +79,7 @@ class Service {
       this.username = currentInfo.username
       this.devicename = currentInfo.devicename
       this.verbose = options ? Boolean(options.verbose) : false
+      this.botLite = options ? Boolean(options.botLite) : true
     }
   }
 
@@ -142,9 +146,10 @@ class Service {
     if (this.serviceLogFile) {
       args.unshift('-d', '--log-file', this.serviceLogFile)
     }
-    const child = spawn(path.join(this.workingDir, 'keybase'), args, {
-      env: Object.assign({KEYBASE_DISABLE_TEAM_AUDITOR: 1}, process.env),
-    })
+    if (this.botLite) {
+      args.unshift('--enable-bot-lite-mode')
+    }
+    const child = spawn('keybase', args, process.env)})
 
     // keep track of the subprocess' state
     this.running = true

--- a/lib/service/index.js
+++ b/lib/service/index.js
@@ -13,6 +13,7 @@ class Service {
   homeDir: void | string
   verbose: boolean
   botLite: boolean
+  disableTyping: boolean
   serviceLogFile: void | string
   workingDir: string
   constructor(workingDir: string) {
@@ -20,6 +21,7 @@ class Service {
     this.initialized = false
     this.verbose = false
     this.botLite = true
+    this.disableTyping = true
   }
 
   async init(username: string, paperkey: string, options?: InitOptions): Promise<void> {
@@ -37,12 +39,23 @@ class Service {
     this.homeDir = this.workingDir
     this.serviceLogFile = path.join(this.homeDir, 'Library', 'Logs', 'keybase.service.log')
     this.botLite = options ? Boolean(typeof options.botLite !== 'boolean' || options.botLite) : true
+    this.disableTyping = options
+      ? Boolean(typeof options.disableTyping !== 'boolean' || options.disableTyping)
+      : true
     // Unlike with clients we don't need to store the service, since it shuts down with ctrl stop
     try {
       await this.startupService()
       await keybaseExec(this.workingDir, this.homeDir, ['oneshot', '--username', username], {
         stdinBuffer: paperkey,
       })
+
+      // Set the typing notification settings for the bot
+      await keybaseExec(this.homeDir, [
+        'chat',
+        'notification-settings',
+        'disable-typing',
+        this.disableTyping.toString(),
+      ])
 
       const currentInfo = await keybaseStatus(this.workingDir, this.homeDir)
 
@@ -119,6 +132,7 @@ class Service {
         devicename: this.devicename,
         homeDir: this.homeDir ? this.homeDir : undefined,
         botLite: this.botLite,
+        disableTyping: this.disableTyping,
       }
     }
     return null

--- a/lib/service/index.js
+++ b/lib/service/index.js
@@ -43,6 +43,7 @@ class Service {
 
     this.homeDir = this.workingDir
     this.serviceLogFile = path.join(this.homeDir, 'Library', 'Logs', 'keybase.service.log')
+    this.botLite = options ? Boolean(options.botLite) : true
     // Unlike with clients we don't need to store the service, since it shuts down with ctrl stop
     try {
       await this.startupService()
@@ -57,7 +58,6 @@ class Service {
         this.username = currentInfo.username
         this.devicename = currentInfo.devicename
         this.verbose = options ? Boolean(options.verbose) : false
-        this.botLite = options ? Boolean(options.botLite) : true
       }
       if (this.username !== username) {
         throw new Error('Failed to initialize service.')
@@ -80,7 +80,6 @@ class Service {
       this.username = currentInfo.username
       this.devicename = currentInfo.devicename
       this.verbose = options ? Boolean(options.verbose) : false
-      this.botLite = options ? Boolean(options.botLite) : true
     }
   }
 

--- a/lib/service/index.js
+++ b/lib/service/index.js
@@ -9,6 +9,7 @@ import path from 'path'
  */
 export type InitOptions = {|
   verbose?: boolean,
+  botLite?: boolean,
 |}
 
 class Service {

--- a/lib/utils/keybaseStatus.js
+++ b/lib/utils/keybaseStatus.js
@@ -2,12 +2,14 @@
 import keybaseExec from '../utils/keybaseExec'
 
 /**
- * Useful information like the username, device, and home directory of your bot.
+ * Useful information like the username, device, home directory of your bot and
+ * configuration options.
  */
 export type BotInfo = {|
   username: string,
   devicename: string,
   homeDir?: string,
+  botLite?: boolean,
 |}
 
 /**

--- a/lib/utils/keybaseStatus.js
+++ b/lib/utils/keybaseStatus.js
@@ -10,6 +10,7 @@ export type BotInfo = {|
   devicename: string,
   homeDir?: string,
   botLite?: boolean,
+  disableTyping?: boolean,
 |}
 
 /**

--- a/lib/utils/options.js
+++ b/lib/utils/options.js
@@ -7,4 +7,6 @@ export type InitOptions = {|
   verbose?: boolean,
   // Disables non-critical background services to improve bot performance.
   botLite?: boolean,
+  // Disable sending/receiving typing notifications to reduce bot bandwidth
+  disableTyping?: boolean,
 |}

--- a/lib/utils/options.js
+++ b/lib/utils/options.js
@@ -1,0 +1,10 @@
+// @flow
+
+/**
+ * Options for initializing the bot.
+ */
+export type InitOptions = {|
+  verbose?: boolean,
+  // Disables non-critical background services to improve bot performance.
+  botLite?: boolean,
+|}


### PR DESCRIPTION
`-enable-mode-lite-mode` supersedes `KEYBASE_DISABLE_TEAM_AUDITOR` and disables some other non essentials. depends on https://github.com/keybase/client/pull/15672 merging