### PR TITLE
Fix EditContent in flow typings: 'messageID' -> 'messageId'

### DIFF
--- a/lib/chat-client/types.js
+++ b/lib/chat-client/types.js
@@ -122,7 +122,7 @@ export type ReactionContent = {|
 export type EditContent = {|
   type: 'edit',
   edit: {|
-    messageID: number,
+    messageId: number,
     body: string,
   |},
 |}


### PR DESCRIPTION
Strangely here https://github.com/keybase/client/blob/b6aadbbd398c09010a6469de78f68b5db80cc9c6/protocol/json/chat1/local.json#L126 it's also written as `messageID`, but I receive `messageId`:

![image](https://user-images.githubusercontent.com/10106819/52478716-eeab0500-2bae-11e9-8578-38e6798832fd.png)

I guess `formatAPIObjectOutput` function changes that?

**upd**: Yep: `require('lodash.camelcase')('messageID') //=> 'messageId'`
 Also it doesn't touch `messageIDs`: `require('lodash.camelcase')('messageIDs') //=> 'messageIDs'`