### PR TITLE
fix m ReactionContent typing

### DIFF
--- a/lib/chat-client/types.d.ts
+++ b/lib/chat-client/types.d.ts
@@ -100,7 +100,7 @@ export interface AttachmentContent {
 export interface ReactionContent {
     type: 'reaction';
     reaction: {
-        m: string;
+        m: number;
         b: string;
     };
 }

--- a/src/chat-client/types.ts
+++ b/src/chat-client/types.ts
@@ -122,7 +122,7 @@ export interface AttachmentContent {
 export interface ReactionContent {
   type: 'reaction'
   reaction: {
-    m: string
+    m: number
     b: string
   }
 }


### PR DESCRIPTION
I think this is a number. The `id` field of `MessageSummary` is `number`: https://github.com/keybase/keybase-bot/blob/71da5e4daacffef5ee09ab080bce1e332d01ee9a/src/chat-client/types.ts#L213

And the `m` field from `api-listen` is `number` instead of `string` too:

```
{"type":"chat","source":"remote","msg":{"id":274,"conversation_id":"0000fc8540f720b1109de1283292545e7fbcdcd813e6126f524193a87abca2c1","channel":{"name":"songgao,songgao_test","public":false,"members_type":"impteamupgrade","topic_type":"chat"},"sender":{"uid":"08abe80bd2da8984534b2d8f7b12c700","username":"songgao","device_id":"189239cee2a9b425ad7016454ae3ad18","device_name":"mbp-kb-20190417"},"sent_at":1562556327,"sent_at_ms":1562556327612,"content":{"type":"reaction","reaction":{"m":271,"b":":+1:"}},"prev":null,"unread":false,"channel_mention":"none"},"pagination":{"next":"cd0112","previous":"cd0112","num":1,"last":false}}
```