### PR TITLE
Mark lib/ directory as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/lib/ linguist-generated=true


### PR DESCRIPTION
This should make the GitHub diffs easier to read by hiding the generated files of `lib/` by default. We do the same thing in the client repo for the generated RPC types!