### PR TITLE
Add types field for use by typescript apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "gpg"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "homepage": "https://github.com/keybase/keybase-bot",
   "repository": "git@github.com:keybase/keybase-bot.git",
   "bugs": {


### PR DESCRIPTION
Adds a `types` entry to the package.json so that typescript apps that use this package can take advantage of our types. See https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package for details.

I was really confused about why my bot import was `any` and this fixes that haha