### PR TITLE
Correct bot advertisements to demo restricted bots

### DIFF
--- a/demos/es7/advertised-echo.js
+++ b/demos/es7/advertised-echo.js
@@ -18,7 +18,7 @@ async function main() {
           type: 'public',
           commands: [
             {
-              name: '!echo',
+              name: 'echo',
               description: 'Sends out your message to the current channel.',
               usage: '[your text]',
             },


### PR DESCRIPTION
Looks like just the advertisement syntax was broken. Otherwise the demo works fine.