### PR TITLE
improve docker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ main()
 
 ```dockerfile
 FROM keybaseio/client:nightly-node
-WORKDIR /home/keybase
+RUN mkdir /app && chown keybase:keybase /app
+WORKDIR /app
 COPY package*.json ./
 RUN npm install # or use yarn
 COPY . .

--- a/README.md
+++ b/README.md
@@ -170,9 +170,10 @@ main()
 
 ```dockerfile
 FROM keybaseio/client:nightly-node
-WORKDIR /app
-COPY . /app
+WORKDIR /home/keybase
+COPY package*.json ./
 RUN npm install # or use yarn
+COPY . .
 CMD node /app/index.js
 ```
 


### PR DESCRIPTION
Hi,
Currently, the example of Dockerfile is error-prone.
When you try to run it with typescript, which generates `/dist` it will fail due to Permission access error.
After some investigation, I've figured out that `keybaseio/client:nightly-node-slim` leave the image with `keybase` user. Command `WORKDIR /app` creates the `/app` directory at root level access, which prevents from creating there `/dist` directory.
My proposal is to set `WORKDIR` to `/home/keybase` (where the user has write access)  by default.
Additionally 
```
COPY package*.json ./
RUN npm install # or use yarn
COPY . .
```
for free performance improvement.
