### PR TITLE
docs: update @example for bot.kvstore.get

### DIFF
--- a/lib/kvstore-client/index.d.ts
+++ b/lib/kvstore-client/index.d.ts
@@ -39,7 +39,7 @@ declare class KVStore extends ClientBase {
      * @param entryKey - The entryKey to get the value for.
      * @returns - An entryKey with its value. If this key does not exist, the revision will be 0.
      * @example
-     * bot.kvstore.get('phoenix', 'pw-manager', 'geocities').then(({revision, value}) => console.log({revision, value}))
+     * bot.kvstore.get('phoenix', 'pw-manager', 'geocities').then(({revision, entryValue}) => console.log({revision, entryValue}))
      */
     get(team: undefined | string, namespace: string, entryKey: string): Promise<keybase1.KVGetResult>;
     /**

--- a/lib/kvstore-client/index.js
+++ b/lib/kvstore-client/index.js
@@ -143,7 +143,7 @@ var KVStore = /** @class */ (function (_super) {
      * @param entryKey - The entryKey to get the value for.
      * @returns - An entryKey with its value. If this key does not exist, the revision will be 0.
      * @example
-     * bot.kvstore.get('phoenix', 'pw-manager', 'geocities').then(({revision, value}) => console.log({revision, value}))
+     * bot.kvstore.get('phoenix', 'pw-manager', 'geocities').then(({revision, entryValue}) => console.log({revision, entryValue}))
      */
     KVStore.prototype.get = function (team, namespace, entryKey) {
         return __awaiter(this, void 0, void 0, function () {

--- a/src/kvstore-client/index.ts
+++ b/src/kvstore-client/index.ts
@@ -68,7 +68,7 @@ class KVStore extends ClientBase {
    * @param entryKey - The entryKey to get the value for.
    * @returns - An entryKey with its value. If this key does not exist, the revision will be 0.
    * @example
-   * bot.kvstore.get('phoenix', 'pw-manager', 'geocities').then(({revision, value}) => console.log({revision, value}))
+   * bot.kvstore.get('phoenix', 'pw-manager', 'geocities').then(({revision, entryValue}) => console.log({revision, entryValue}))
    */
   public async get(team: undefined | string, namespace: string, entryKey: string): Promise<keybase1.KVGetResult> {
     await this._guardInitialized()


### PR DESCRIPTION
Correct destructured fulfillment value (c.f. keybase1.KVGetResult)